### PR TITLE
Add Player Queue feature for Spotify playback queue display

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import {SpotifyAuthHandler} from "./components/spotify/SpotifyAuthHandler.tsx";
 import {AppContent} from "@/AppContent.tsx";
 import {AuthProvider} from "@/components/auth/contexts/AuthProvider.tsx";
 import RecentlyPlayed from "@/components/spotify/RecentlyPlayed.tsx";
+import PlayerQueue from "@/components/spotify/PlayerQueue.tsx";
 
 const queryClient = new QueryClient();
 
@@ -20,6 +21,7 @@ function App() {
             />
             <Route path="/" element={<AppContent />} />
             <Route path="/recently-played" element={<RecentlyPlayed />} />
+            <Route path="/player-queue" element={<PlayerQueue />} />
           </Routes>
         </BrowserRouter>
       </AuthProvider>

--- a/src/components/AppSidebar.tsx
+++ b/src/components/AppSidebar.tsx
@@ -21,8 +21,13 @@ const items = [
     icon: Home
   },
   {
+    title: "Player Queue",
+    url: "/player-queue",
+    icon: Search
+  },
+  {
     title: "Recently Played",
-    url: "/recently-played#",
+    url: "/recently-played",
     icon: Search
   },
   {

--- a/src/components/Login.tsx
+++ b/src/components/Login.tsx
@@ -3,7 +3,7 @@ import {Button} from "@/components/ui/button.tsx";
 
 const SPOTIFY_AUTH_ENDPOINT = "https://accounts.spotify.com/authorize";
 const REDIRECT_URI = "http://localhost:5173/callback";
-const SCOPES = ["user-read-recently-played"];
+const SCOPES = ["user-read-recently-played", "user-read-currently-playing", "user-read-playback-state"];
 
 // PKCE Helper functions
 async function generateCodeChallenge(codeVerifier: string) {

--- a/src/components/spotify/PlayerQueue.tsx
+++ b/src/components/spotify/PlayerQueue.tsx
@@ -1,0 +1,103 @@
+import {useQuery} from "@tanstack/react-query";
+import {
+  SpotifyTrack,
+  PlayerQueueResponse,
+  SpotifyArtist,
+} from "@/components/spotify/types/SpotifyTypes.ts";
+import BaseLayout from "@/components/BaseLayout.tsx";
+import { AuthContextProps } from "@/components/auth/contexts/AuthContext.tsx";
+import {useAuthHook} from "@/components/auth/hooks/useAuthHook.tsx";
+import {Login} from "@/components/Login.tsx";
+
+const PLAYER_QUEUE_URL =
+  "https://api.spotify.com/v1/me/player/queue";
+
+async function getPlayerQueue(
+  authContextProps: AuthContextProps,
+) {
+  const response = await fetch(PLAYER_QUEUE_URL, {
+    headers: {
+      Authorization: `Bearer ${authContextProps.authState.accessToken}`,
+    },
+  });
+
+  if (response.status === 401) {
+    authContextProps.setAuthState({...authContextProps.authState, isAuthenticated: false});
+    throw new Error("Access token expired");
+  }
+
+  if (!response.ok) {
+    throw new Error("Failed to fetch player queue");
+  }
+
+  return response.json();
+}
+
+export function PlayerQueue() {
+  const authContextProps = useAuthHook();
+
+  const playerQueueQuery = useQuery<PlayerQueueResponse>({
+    queryKey: ['playerQueue'],
+    queryFn: () => getPlayerQueue(authContextProps),
+    enabled: authContextProps.authState.isAuthenticated,
+  });
+
+  if (!authContextProps.authState || !authContextProps.authState.isAuthenticated) {
+    return (
+      <Login />
+    );
+  }
+
+  return (
+    <BaseLayout>
+      {/* Full-screen background with muted blue */}
+      <div className="w-screen min-h-screen opacity-2 bg-gray-100 dark:bg-gray-800 flex flex-col items-start p-4">
+        <h1 className="text-2xl md:text-3xl font-bold mb-6 text-center text-zinc-800 dark:text-zinc-200">
+          Your Queue
+        </h1>
+
+        {/* Display loading, error, or the recently played tracks */}
+        {playerQueueQuery.isPending && (
+          <div className="text-center">Loading your queue...</div>
+        )}
+
+        {playerQueueQuery.isError && (
+          <div className="text-red-500 text-center mt-4">
+            Error fetching your queue!
+          </div>
+        )}
+
+        {playerQueueQuery.data && (
+          <div className="w-11/12 md:w-3/4 lg:w-2/3 space-y-4">
+            {playerQueueQuery.data.queue.map((item: SpotifyTrack, index: number) => (
+              <div key={index} className="bg-white dark:bg-gray-700 rounded-lg p-4 shadow-lg flex items-center space-x-4">
+                {/* Album Cover */}
+                {item.album.images[0] && (
+                  <img
+                    src={item.album.images[0].url}
+                    alt={item.album.name}
+                    className="w-16 h-16 sm:w-20 sm:h-20 rounded"
+                  />
+                )}
+
+                {/* Track and Artist Info */}
+                <div>
+                  <h3 className="text-lg font-semibold text-blue-500 dark:text-amber-100 opacity-70">{item.name}</h3>
+                  <p className="text-gray-500 dark:text-gray-400 text-sm">
+                    {item.artists.map((artist: SpotifyArtist) => artist.name).join(", ")}
+                  </p>
+                  {/*<p className="text-sm text-gray-400 dark:text-gray-500">*/}
+                  {/*  {new Date(item.played_at).toLocaleString()}*/}
+                  {/*</p>*/}
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </BaseLayout>
+  );
+
+}
+
+export default PlayerQueue;

--- a/src/components/spotify/types/SpotifyTypes.ts
+++ b/src/components/spotify/types/SpotifyTypes.ts
@@ -25,3 +25,8 @@ export interface RecentlyPlayedItem {
 export interface RecentlyPlayedResponse {
   items: RecentlyPlayedItem[];
 }
+
+export interface PlayerQueueResponse {
+  currently_playing: SpotifyTrack;
+  queue: SpotifyTrack[];
+}


### PR DESCRIPTION
### Description

This pull request introduces the **Player Queue feature**, enabling users to view their Spotify playback queue. Key updates include:

- Addition of a new **Player Queue component** for displaying the playback queue.
- Integration with Spotify's API for queue data retrieval.
- User interface updates to the sidebar and router to accommodate the new feature.
- Updates to Spotify permission scopes to support the required functionality.

### Checklist

- [ ] The code compiles without errors.
- [ ] All tests have been written and pass successfully.
- [ ] Relevant documentation has been added or updated.
- [ ] Code has been reviewed for best practices and coding standards.
- [ ] Additional dependencies have been documented and explained if